### PR TITLE
Update site

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,5 +75,11 @@ jobs:
         ls
         git status
         git remote show origin
-      # git add covid19
-      # git commit -m "Update covid19"
+        git add -A
+        git diff-index --quiet HEAD || git commit -m 'Update world data'
+    
+    - uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master
+        repository: 'enrichman/enrichman.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: 'master'
+        token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
         repository: 'enrichman/enrichman.github.io'
     - name: Download files
       uses: actions/download-artifact@v1
@@ -75,7 +75,6 @@ jobs:
       run: |
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
-        git push -u origin master
     
     - uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,6 @@ jobs:
         path: covid19/world
     - name: Run a multi-line script
       run: |
-        cd site
         ls
         git status
       # git add covid19

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,10 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        cp -r world covid19/world
+        mv world covid19/world
         git status
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,15 +70,15 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: world
-        path: covid19/world
+    
     - name: Run a multi-line script
       run: |
-        pwd
         ls
+        git status
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     
-    - uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
-        repository: 'enrichman/enrichman.github.io'
+    # - uses: ad-m/github-push-action@master
+    #   with:
+    #     github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
+    #     repository: 'enrichman/enrichman.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   schedule:
     - cron:  '0 * * * *'
+  push:
+    branches: [ update-site ]
 
 jobs:
   clone-source:
@@ -43,34 +45,38 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git commit -m "Update data" -a
+        git diff-index --quiet HEAD || git commit -m "Update data" -a
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: master
+    - name: Upload files
+      uses: actions/upload-artifact@v1
+      with:
+        name: world
+        path: world
   create-site:
     needs: update-data
     runs-on: ubuntu-latest
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-      with:
-        path: main
     - uses: actions/checkout@v2
       with:
         path: site
+        ref: 'master'
         repository: 'enrichman/enrichman.github.io'
-  
-    # Runs a set of commands using the runners shell
+    - name: Download files
+      uses: actions/download-artifact@v1
+      with:
+        name: world
+        path: site/covid19/world
     - name: Run a multi-line script
       run: |
-        mkdir site/covid19
-        mv main/world site/covid19/
-        cd site
-        git add covid19
-        git commit -m "Update covid19"
+        ls
+      # git add covid19
+      # git commit -m "Update covid19"
     
     - uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,8 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        cp -r world covid19/
-        rm -fr world
+        rm -fr covid19/world
+        mv world covid19
         git status
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@
 name: CI
 
 on:
+  push:
+    branches:    
+      - update-site  
   schedule:
     - cron:  '0 * * * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Generate new files
       run: |
         go build .
-       ./covid19
-       rm covid19
+        ./covid19
+        rm covid19
     - name: Push on our repo
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,6 @@
-# This is a basic workflow to help you get started with Actions
+name: Update data from CSSEGISandData
 
-name: CI
-
-on:
-  push:
-    branches:    
-      - update-site  
+on: 
   schedule:
     - cron:  '0 * * * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,8 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        mv world covid19
+        cp world covid19/
+        rm -fr world
         git status
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,9 @@ jobs:
         name: csv
         path: csv
     - name: Generate new files
-      run: go run main.go
+      run: |
+        go version
+        go run main.go
     - name: Push on our repo
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,14 +63,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        path: site
         ref: 'master'
         repository: 'enrichman/enrichman.github.io'
     - name: Download files
       uses: actions/download-artifact@v1
       with:
         name: world
-        path: site/covid19/world
+        path: covid19/world
     - name: Run a multi-line script
       run: |
         cd site

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,9 @@ jobs:
         path: csv
     - name: Generate new files
       run: |
-        go version
-        go run main.go
+        go build .
+       ./covid19
+       rm covid19
     - name: Push on our repo
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        ls
+        cp -r world covid19/world
         git status
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,10 +74,6 @@ jobs:
       run: |
         ls
         git status
+        git remote show origin
       # git add covid19
       # git commit -m "Update covid19"
-    
-    - uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
       run: |
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
+        git push -u origin master
     
     - uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        cp world covid19/
+        cp -r world covid19/
         rm -fr world
         git status
         git config --local user.email "action@github.com"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: update-site
+        branch: master
     - name: Upload files
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
         path: covid19/world
     - name: Run a multi-line script
       run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,4 @@ jobs:
     - uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
-        branch: master
         repository: 'enrichman/enrichman.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
         path: covid19/world
     - name: Run a multi-line script
       run: |
-        git add world
+        git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     
     - uses: ad-m/github-push-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,8 @@ jobs:
         path: covid19/world
     - name: Run a multi-line script
       run: |
+        pwd
+        ls
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git diff-index --quiet HEAD || git commit -m "Update data" -a
+        git add -A
+        git diff-index --quiet HEAD || git commit -m 'Update data'
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     
     - name: Run a multi-line script
       run: |
-        mv world covid19/world
+        mv world covid19
         git status
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ name: CI
 on:
   schedule:
     - cron:  '0 * * * *'
-  push:
-    branches: [ update-site ]
 
 jobs:
   clone-source:
@@ -72,14 +70,11 @@ jobs:
         path: covid19/world
     - name: Run a multi-line script
       run: |
-        ls
-        git status
-        git remote show origin
-        git add -A
+        git add world
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     
     - uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
         branch: master
         repository: 'enrichman/enrichman.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,18 +70,13 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: world
-    
+        path: covid19/world
     - name: Run a multi-line script
       run: |
-        rm -fr covid19/world
-        mv world covid19
-        git status
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
         git add covid19
         git diff-index --quiet HEAD || git commit -m 'Update world data'
     
-    # - uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
-    #     repository: 'enrichman/enrichman.github.io'
+    - uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.ENRICHMAN_GH_TOKEN }}
+        repository: 'enrichman/enrichman.github.io'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,9 @@ jobs:
         path: site/covid19/world
     - name: Run a multi-line script
       run: |
+        cd site
         ls
+        git status
       # git add covid19
       # git commit -m "Update covid19"
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         name: csv
         path: csv
+    - name: Generate new files
+      run: go run main.go
     - name: Push on our repo
       run: |
         git config --local user.email "action@github.com"
@@ -52,7 +54,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: master
+        branch: update-site
     - name: Upload files
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
Extending action to automatically update site repo. Also fixed issue with `git commit` when no changes are coming from our master data.

To make it run we need to have a token for pushing to https://github.com/enrichman/enrichman.github.io, @enrichman as the repo owner you should generate it. I refer to it as `ENRICHMAN_GH_TOKEN` but feel free to change that name.